### PR TITLE
MNT: Bump to 3.0.0. 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fmrib-unpack" %}
-{% set version = "2.9.1" %}
-{% set sha256 = "6f5cafc0827bffd25628152d7b0b881fb9a680d8275129672db1160c77001542" %}
+{% set version = "3.0.0" %}
+{% set sha256 = "5d1033beb8afb554732be2a9f641203d56cd37e646c6a90a37755b2a973f6841" %}
 
 package:
   name: {{ name|lower }}
@@ -15,8 +15,8 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
-    - funpack      = funpack.main:main
-    - funpack_demo = funpack.scripts.demo:main
+    - fmrib_unpack      = funpack.main:main
+    - fmrib_unpack_demo = funpack.scripts.demo:main
 
 requirements:
   host:
@@ -45,8 +45,8 @@ test:
     - jinja2
 
   commands:
-    - funpack -V
-    - funpack_demo -h
+    - fmrib_unpack -V
+    - fmrib_unpack_demo -h
 
 # check test markers
     - pytest -v --cov=funpack --pyargs funpack.tests -k "not (lowMemory or HDF or test_demo)"

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,5 +1,13 @@
+# FSL 6.0.5 and older
 if [ -e ${FSLDIR}/etc/fslconf/requestFSLpythonLink.sh ]; then
   $FSLDIR/etc/fslconf/requestFSLpythonLink.sh \
-    funpack \
-    funpack_demo
+    fmrib_unpack                              \
+    fmrib_unpack_demo
+# FSL 6.0.6 and newer
+elif  [ -e ${FSLDIR}/share/fsl/sbin/createFSLWrapper ]; then
+  $FSLDIR/share/fsl/sbin/createFSLWrapper \
+    fmrib_unpack                          \
+    fmrib_unpack_demo                     \
+    fmrib_unpack=funpack                  \
+    fmrib_unpack_demo=funpack_demo
 fi

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,5 +1,12 @@
 if [ -e ${FSLDIR}/etc/fslconf/requestFSLpythonUnlink.sh ]; then
   $FSLDIR/etc/fslconf/requestFSLpythonUnlink.sh \
-    funpack \
-    funpack_demo
+    fmrib_unpack                                \
+    fmrib_unpack_demo
+# FSL 6.0.6 and newer
+elif  [ -e ${FSLDIR}/share/fsl/sbin/removeFSLWrapper ]; then
+  $FSLDIR/share/fsl/sbin/removeFSLWrapper \
+    fmrib_unpack                          \
+    fmrib_unpack_demo                     \
+    fmrib_unpack=funpack                  \
+    fmrib_unpack_demo=funpack_demo
 fi


### PR DESCRIPTION
The main funpack entry point has been changed to `fmrib_unpack`, to avoid conflict with `cfitsio`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
